### PR TITLE
`verify_keyring` exiting with Key Not Found...

### DIFF
--- a/strap.sh
+++ b/strap.sh
@@ -51,7 +51,7 @@ fetch_keyring()
 verify_keyring()
 {
     gpg \
-        --keyserver http://pgp.mit.edu \
+        --keyserver pgp.mit.edu \
         --recv-keys 4345771566D76038C7FEB43863EC0ADBEA87E4E3 > /dev/null 2>&1
 
     if ! gpg \


### PR DESCRIPTION
After a few tests I could narrow down the problem to the use of scheme, HTTPS, in the `gpg` command responsible to fetch the pubkey.

**--------- SOLUTION FOR NOW ---------**
```
curl -O https://raw.githubusercontent.com/PedroSFreitas/blackarch-site/strap-sh-patch/strap.sh
chmod +x strap.sh
sudo ./strap.sh
```

sha1sum: 6f152b79419491db92c1fdde3fad2d445f09aae3