### PR TITLE
strap.sh: implementing new errors check and refactoring.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 sync.sh
-.swp
+*.swp
 .swo
 .swn
 !google522f29024a3304e0.html

--- a/strap.sh
+++ b/strap.sh
@@ -40,15 +40,15 @@ make_tmp_dir()
 }
 
 check_internet()
-{    
-    if ! ping -s 0 -c 1 -W 2 google.com > /dev/null 2>&1; then
-        if ping -s 0 -c 1 -W 2 8.8.8.8 > /dev/null 2>&1; then
+{
+    if ! ping -c 3 -W 3 google.com > /dev/null 2>&1; then
+        if ping -c 3 -W 3 8.8.8.8 > /dev/null 2>&1; then
             warn "you have internet connection but seems to have a problem with DNS"
         else
             err "you don't have an internet connection"
         fi
     fi
-    
+
     return $SUCCESS
 }
 
@@ -100,8 +100,8 @@ install_keyring()
     then
         err 'keyring installation failed'
     fi
-	# just in case
-	pacman-key --populate
+    # just in case
+    pacman-key --populate
 }
 
 # ask user for mirror
@@ -150,7 +150,7 @@ pacman_update()
     if pacman -Syy; then
         return $SUCCESS
     fi
-    
+
     warn "Synchronizing pacman has failed. Please try manually: pacman -Syy"
     return $FAILURE
 }

--- a/strap.sh
+++ b/strap.sh
@@ -7,20 +7,20 @@ MIRROR='https://www.mirrorservice.org/sites/blackarch.org/blackarch/'
 # simple error message wrapper
 err()
 {
-    echo >&2 `tput bold; tput setaf 1`"[-] ERROR: ${*}"`tput sgr0`
+    echo >&2 "$(tput bold; tput setaf 1)[-] ERROR: ${*}$(tput sgr0)"
     exit 1337
 }
 
 # simple warning message wrapper
 warn()
 {
-    echo >&2 `tput bold; tput setaf 1`"[!] WARNING: ${*}"`tput sgr0`
+    echo >&2 "$(tput bold; tput setaf 1)[!] WARNING: ${*}$(tput sgr0)"
 }
 
 # simple echo wrapper
 msg()
 {
-    echo `tput bold; tput setaf 2`"[+] ${*}"`tput sgr0`
+    echo "$(tput bold; tput setaf 2)[+] ${*}$(tput sgr0)"
 }
 
 # check for root privilege
@@ -34,7 +34,7 @@ check_priv()
 # make a temporary directory and cd into
 make_tmp_dir()
 {
-    tmp=`mktemp -d /tmp/blackarch_strap.XXXXXXXX`
+    tmp="$(mktemp -d /tmp/blackarch_strap.XXXXXXXX)"
     trap "rm -rf $tmp" EXIT
     cd "$tmp"
 }

--- a/strap.sh
+++ b/strap.sh
@@ -35,7 +35,7 @@ check_priv()
 make_tmp_dir()
 {
     tmp="$(mktemp -d /tmp/blackarch_strap.XXXXXXXX)"
-    trap "rm -rf $tmp" EXIT
+    trap 'rm -rf $tmp' EXIT
     cd "$tmp"
 }
 

--- a/strap.sh
+++ b/strap.sh
@@ -63,18 +63,21 @@ fetch_keyring()
 # note: this is pointless if you do not verify the key fingerprint
 verify_keyring()
 {
-    if ! gpg \
-        --keyserver pgp.mit.edu \
-        --recv-keys 4345771566D76038C7FEB43863EC0ADBEA87E4E3 > /dev/null 2>&1
+    if ! gpg --keyserver pgp.mit.edu \
+             --recv-keys 4345771566D76038C7FEB43863EC0ADBEA87E4E3 > /dev/null 2>&1
     then
-        err 'could not verify the key, check your network (firewall, dns, time)'
+        if ! gpg --keyserver hkp://pool.sks-keyservers.net \
+                 --recv-keys 4345771566D76038C7FEB43863EC0ADBEA87E4E3 > /dev/null 2>&1
+        then
+            err "could not verify the key, check your network (firewall, dns, time)"
+        fi
     fi
 
     if ! gpg \
         --keyserver-options no-auto-key-retrieve \
         --with-fingerprint blackarch-keyring.pkg.tar.xz.sig > /dev/null 2>&1
     then
-        err 'invalid keyring signature. please stop by irc.freenode.net/blackarch'
+        err "invalid keyring signature. please stop by irc.freenode.net/blackarch"
     fi
 }
 

--- a/strap.sh
+++ b/strap.sh
@@ -26,7 +26,7 @@ msg()
 # check for root privilege
 check_priv()
 {
-    if [ $EUID -ne 0 ] ; then
+    if [ "$(id -u)" -ne 0 ] ; then
         err "you must be root"
     fi
 }

--- a/strap.sh
+++ b/strap.sh
@@ -36,7 +36,7 @@ make_tmp_dir()
 {
     tmp="$(mktemp -d /tmp/blackarch_strap.XXXXXXXX)"
     trap 'rm -rf $tmp' EXIT
-    cd "$tmp"
+    cd "$tmp" || err "Could not enter directory $tmp"
 }
 
 # retrieve the BlackArch Linux keyring
@@ -91,7 +91,7 @@ install_keyring()
 # ask user for mirror
 get_mirror()
 {
-    printf "    -> enter a BlackArch Linux mirror url (default: $MIRROR): "
+    printf "    -> enter a BlackArch Linux mirror url (default: %s): " "$MIRROR"
     while read line ; do
         case "$line" in
             http://*|https://*|ftp://*)

--- a/strap.sh
+++ b/strap.sh
@@ -69,7 +69,7 @@ verify_keyring()
         if ! gpg --keyserver hkp://pool.sks-keyservers.net \
                  --recv-keys 4345771566D76038C7FEB43863EC0ADBEA87E4E3 > /dev/null 2>&1
         then
-            err "could not verify the key, check your network (firewall, dns, time)"
+            err "could not verify the key. Please check: https://blackarch.org/faq.html"
         fi
     fi
 

--- a/strap.sh
+++ b/strap.sh
@@ -131,7 +131,12 @@ EOF
 # synchronize and update
 pacman_update()
 {
-    pacman -Syy
+    if pacman -Syy; then
+        return $SUCCESS
+    fi
+    
+    warn "Synchronizing pacman has failed. Please try manually: pacman -Syy"
+    return $FAILURE
 }
 
 


### PR DESCRIPTION
We're seeing a lot of users on IRC (server: Freenode) receiving "invalid keyring" error message when it usually is a network/internet misconfiguration or problem.
This PR tries to create useful checks and error messages, although it's probably not 100% correct. It'd be interesting to have a second eyes on it.
Any critics, positive or negative are much appreciated.

And I tried to refactor a few things according to https://github.com/koalaman/shellcheck

Note: I've tried to provide enough information on the commit messages, it'd be interesting to read them in order to understand the changes.