### PR TITLE
mirrorlist: default to blackarch.org.

### DIFF
--- a/blackarch-mirrorlist
+++ b/blackarch-mirrorlist
@@ -22,7 +22,7 @@
 # Server = http://mirror.espoch.edu.ec/blackarch/$repo/os/$arch
 
 # France
-# Server = https://www.blackarch.org/blackarch/$repo/os/$arch
+ Server = https://www.blackarch.org/blackarch/$repo/os/$arch
 # Server = rsync://blackarch.org/blackarch/$repo/os/$arch
 # Server = http://blackarch.tamcore.eu/blackarch/$repo/os/$arch
 # Server = https://blackarch.tamcore.eu/blackarch/$repo/os/$arch
@@ -42,7 +42,7 @@
 # Server = rsync://blackarch@cc.uoc.gr/blackarch/$repo/os/$arch
 
 # Great Britain
-Server = http://www.mirrorservice.org/sites/blackarch.org/blackarch/$repo/os/$arch
+# Server = http://www.mirrorservice.org/sites/blackarch.org/blackarch/$repo/os/$arch
 # Server = rsync://rsync.mirrorservice.org/blackarch.org/blackarch/$repo/os/$arch
 
 # Ireland


### PR DESCRIPTION
This PR changes the default mirror to blackarch.org.
- mirrorservice is down (dns expired).

https://github.com/BlackArch/blackarch/issues/1961