### PR TITLE
remove auto-xor-decryptor

### DIFF
--- a/data/crypto
+++ b/data/crypto
@@ -1,6 +1,5 @@
 aespipe|2.4d|Reads data from stdin and outputs encrypted or decrypted results to stdout.|http://loop-aes.sourceforge.net/aespipe/
 argon2|20171227|A password-hashing function (reference C implementation)|https://github.com/P-H-C/phc-winner-argon2
-auto-xor-decryptor|7.2eb176d|Automatic XOR decryptor tool.|http://www.blog.mrg-effitas.com/publishing-of-mrg-effitas-automatic-xor-decryptor-tool/
 bletchley|0.0.1|A collection of practical application cryptanalysis tools.|https://code.google.com/p/bletchley/
 ciphertest|22.e33eb4a|A better SSL cipher checker using gnutls.|https://github.com/OpenSecurityResearch/ciphertest
 ciphr|105.db79691|A CLI tool for encoding, decoding, encryption, decryption, and hashing streams of data.|https://github.com/frohoff/ciphr


### PR DESCRIPTION
auto-xor-decryptor link is broken

Broken link (http://www.blog.mrg-effitas.com/publishing-of-mrg-effitas-automatic-xor-decryptor-tool)

![image](https://user-images.githubusercontent.com/16673094/43142753-bf8c36f6-8f76-11e8-93b1-2296af6d6e80.png)
