### PR TITLE
Temp disable torrent hyperlink

### DIFF
--- a/generators/downloads.html.sh
+++ b/generators/downloads.html.sh
@@ -68,7 +68,7 @@ cat << EOF
                 <tr>
                   <td><a href="https://ftp.halifax.rwth-aachen.de/blackarch/iso/blackarch-linux-slim-2021.03.01-x86_64.iso" itemprop="fileFormat" type="application/x-iso9660-image">BlackArch Linux 64 bit Slim ISO</a></td>
                   <td itemprop="datePublished">2021.03.01</td>
-                  <td><a href="/blackarch/torrent/blackarch-linux-slim-2021.03.01-x86_64.iso.torrent" itemprop="fileFormat" type="application/octet-stream">Torrent</a></td>
+                  <td><a style="pointer-events:none; cursor:normal; color:grey;" href="/blackarch/torrent/blackarch-linux-slim-2021.03.01-x86_64.iso.torrent" itemprop="fileFormat" type="application/octet-stream">WIP</a></td>
                   <td>4.5 GB</td>
                   <td>${SLIM_CHECKSUM}</td>
                 </tr>


### PR DESCRIPTION
We can revert this when the `.torrent` is uploaded. 

![image](https://user-images.githubusercontent.com/9546091/110296914-e4bb9080-8018-11eb-8c79-c3ba32e7985e.png)
