### PR TITLE
strap.sh: internet connection source change

### DIFF
--- a/strap.sh
+++ b/strap.sh
@@ -47,7 +47,7 @@ check_internet()
   tool='curl'
   tool_opts='-s --connect-timeout 8'
 
-  if ! $tool $tool_opts https://www.microsoft.com/ > /dev/null 2>&1; then
+  if ! $tool $tool_opts https://example.com/ > /dev/null 2>&1; then
     err "You don't have an Internet connection!"
   fi
 


### PR DESCRIPTION
It was ironic to check internet connection from Microsoft's website. So, I searched a bit and realized that websites like ```example.com``` and ```example.org``` are owned by IANA itself. It'll be better to check internet connection from this website, rather than the previous one.

Refs:
https://www.iana.org/domains/reserved
https://www.rfc-editor.org/rfc/rfc2606.html