### PR TITLE
Update dr460nf1r3s mirror to .org

### DIFF
--- a/blackarch-mirrorlist
+++ b/blackarch-mirrorlist
@@ -39,7 +39,7 @@
 #Server = https://mirror.cyberbits.eu/blackarch/$repo/os/$arch
 
 # Germany
-#Server = https://mirrors.dr460nf1r3.me/repos/blackarch/$repo/os/$arch
+#Server = https://mirrors.dr460nf1r3.org/repos/blackarch/$repo/os/$arch
 #Server = http://ftp.halifax.rwth-aachen.de/blackarch/$repo/os/$arch
 Server = https://ftp.halifax.rwth-aachen.de/blackarch/$repo/os/$arch
 #Server = ftp://ftp.halifax.rwth-aachen.de/blackarch/$repo/os/$arch


### PR DESCRIPTION
I changed my TLD to .org lately, which makes this change required. 