### PR TITLE
remove the command to install all tools

### DIFF
--- a/generators/downloads.html.sh
+++ b/generators/downloads.html.sh
@@ -163,8 +163,6 @@ cat << EOF
               <div class=code-block>
                 <p># To list all of the available tools, run </p>
                 $ <span>sudo pacman -Sgg | grep blackarch | cut -d' ' -f2 | sort -u</span>
-                <p># To try to install all of the tools (2800+), PLEASE DON'T DO THIS and prefer to install only what you need</p>
-                $ <span>sudo pacman -S blackarch</span>
                 <p># To install a category of tools, run</p>
                 $ <span>sudo pacman -S blackarch-&lt;category&gt;</span>
                 <p># To see the blackarch categories, run</p>

--- a/generators/downloads.html.sh
+++ b/generators/downloads.html.sh
@@ -163,7 +163,7 @@ cat << EOF
               <div class=code-block>
                 <p># To list all of the available tools, run </p>
                 $ <span>sudo pacman -Sgg | grep blackarch | cut -d' ' -f2 | sort -u</span>
-                <p># To install all of the tools, run</p>
+                <p># To try to install all of the tools (2800+), PLEASE DON'T DO THIS and prefer to install only what you need</p>
                 $ <span>sudo pacman -S blackarch</span>
                 <p># To install a category of tools, run</p>
                 $ <span>sudo pacman -S blackarch-&lt;category&gt;</span>


### PR DESCRIPTION
**TRYING** to install all 2800 tools with `pacman -S blackarch` **NEVER** work because there is always at least a tool that will fail to install. I'm personally for just **removing** that line but if some want no to here I propose a modification that hint people that it is highly not recommended rather than being highlighted as one of the first commands.

A lot of issues reported concerns people asking for support because `pacman -S blackarch` failed (of course). Eg. the last one `https://github.com/BlackArch/blackarch/issues/3338` in date but there are tons.

Also installing all 2800 tools is ~~nearly~~ useless, because nobody will use all the tools, and even if for some edge reason someone want all tools installed they can install the full ISO or full OVA rather than picking the netinstall and run `pacman -S blackarch`.