### PR TITLE
Set and reset umask in strap.sh

### DIFF
--- a/checksums/strap
+++ b/checksums/strap
@@ -1,1 +1,1 @@
-8bfe5a569ba7d3b055077a4e5ceada94119cccef  strap.sh
+72879737108c0ba1baa49a8847bbdff4e5dcba72  strap.sh

--- a/strap.sh
+++ b/strap.sh
@@ -42,6 +42,18 @@ make_tmp_dir()
   cd "$tmp" || err "Could not enter directory $tmp"
 }
 
+set_umask()
+{
+    OLD_UMASK=$(umask)
+    umask 0022
+    trap 'reset_umask' TERM
+}
+
+reset_umask()
+{
+    umask "$OLD_UMASK"
+}
+
 check_internet()
 {
   tool='curl'
@@ -169,6 +181,7 @@ blackarch_setup()
 {
   check_priv
   msg 'installing blackarch keyring...'
+  set_umask
   make_tmp_dir
   check_internet
   fetch_keyring
@@ -187,6 +200,7 @@ blackarch_setup()
   fi
   msg 'updating package databases'
   pacman_update
+  reset_umask
   msg 'BlackArch Linux is ready!'
 }
 


### PR DESCRIPTION
This fixes an issue wherein if the umask was set to 0077, files created by strap.sh would be -rw-------, which led to pacman errors on full system upgrades after installation.

Signed-off-by: Atrate <Atrate@protonmail.com>