### PR TITLE
New mirror in Taiwan

### DIFF
--- a/blackarch-mirrorlist
+++ b/blackarch-mirrorlist
@@ -119,6 +119,8 @@ Server = https://ftp.halifax.rwth-aachen.de/blackarch/$repo/os/$arch
 
 # Taiwan
 #Server = http://blackarch.cs.nctu.edu.tw/$repo/os/$arch
+#Server = http://mirror.archlinux.tw/BlackArch/$repo/os/$arch
+#Server = https://mirror.archlinux.tw/BlackArch/$repo/os/$arch
 
 # UK
 #Server = http://mirrors.gethosted.online/blackarch/$repo/os/$arch


### PR DESCRIPTION
Mirror domain name: mirror.archlinux.tw
Mirror IP: 125.228.118.224
Geographical location of the mirror (country): Taiwan
URLs for supported access methods (http(s), rsync) (no ftp):
* http://mirror.archlinux.tw/BlackArch/
* https://mirror.archlinux.tw/BlackArch/
* rsync://mirror.archlinux.tw/blackarch/

Mirror's available bandwidth: 250 Mbit/s
An administrative contact email: PingNote.Wu@gmail.com
An alternative administrative contact email: archlinux-tw-general@googlegroups.com

Synced hourly via systemd timer to rsync://mirror.math.princeton.edu/pub/blackarch/