### PR TITLE
Fix Check_Internet domain

### DIFF
--- a/strap.sh
+++ b/strap.sh
@@ -61,7 +61,7 @@ check_internet()
   tool='curl'
   tool_opts='-s --connect-timeout 8'
 
-  if ! $tool $tool_opts https://example.com/ > /dev/null 2>&1; then
+  if ! $tool $tool_opts https://blackarch.org/ > /dev/null 2>&1; then
     err "You don't have an Internet connection!"
   fi
 


### PR DESCRIPTION
# critical fix: 🚑 Fix Check_Internet

Replace ``example.com`` with official BlackArch's URL ``blackarch.org`` on line `64`

This fixes [Issue #153](https://github.com/BlackArch/blackarch-site/issues/153)

```diff
-   if ! $tool $tool_opts https://example.com/ > /dev/null 2>&1; then
+   if ! $tool $tool_opts https://blackarch.org/ > /dev/null 2>&1; then
```

### The issue has existed for a long time and is _**CRITICAL**_ for new beginners in BlackArch. 

If this was meant to be a _"CTF"_ please reference it as a comment in the file in order to not cause confusion among other comrades

 -Yon Liud :)