### PR TITLE
search and do not install all

### DIFF
--- a/generators/downloads.html.sh
+++ b/generators/downloads.html.sh
@@ -167,10 +167,12 @@ cat << EOF
                 $ <span>sudo pacman -S blackarch-&lt;category&gt;</span>
                 <p># To see the blackarch categories, run</p>
                 $ <span>sudo pacman -Sg | grep blackarch</span>
+                <p># To search for a specific package, run</p>
+                $ <span>pacman -Ss &lt;package_name&gt;</span>
                 <p># Note - it maybe be necessary to overwrite certain packages when installing blackarch tools. If<br>
                    # you experience "failed to commit transaction" errors, use the --needed and --overwrite switches<br>
                    # For example:</p>
-                $ <span>sudo pacman -Syyu --needed blackarch --overwrite='*'</span>
+                $ <span>sudo pacman -Syyu --needed --overwrite='*' &lt;wanted-package&gt;</span>
               </div>
               <p>The complete tool list of the BlackArch Linux repository can be found <a href="tools.html" target="_blank">here</a>.</p>
             </li>


### PR DESCRIPTION
I have added the `pacman -Ss <package_name>` command to search for packages.

Also, I changed a command that will result in installing the meta group `blackarch` for the same reasons as #152 (see https://github.com/BlackArch/blackarch/issues/3465).

```diff
-sudo pacman -Syyu --needed blackarch --overwrite='*'
+sudo pacman -Syyu --needed  --overwrite='*' <wanted_package>
```