### PR TITLE
Change the mirror domain name: nctu -> nycu

### DIFF
--- a/blackarch-mirrorlist
+++ b/blackarch-mirrorlist
@@ -118,7 +118,8 @@ Server = https://ftp.halifax.rwth-aachen.de/blackarch/$repo/os/$arch
 #Server = ftp://ftp.linux.org.tr/blackarch/$repo/os/$arch
 
 # Taiwan
-#Server = http://blackarch.cs.nctu.edu.tw/$repo/os/$arch
+#Server = http://blackarch.cs.nycu.edu.tw/$repo/os/$arch
+#Server = https://blackarch.cs.nycu.edu.tw/$repo/os/$arch
 #Server = http://mirror.archlinux.tw/BlackArch/$repo/os/$arch
 #Server = https://mirror.archlinux.tw/BlackArch/$repo/os/$arch
 


### PR DESCRIPTION
Hi,
we would like to change our mirror domain name and contact information due to our school being merged with NYMU into NYCU (National Yang Ming Chiao Tung University).

The following is our new information, and we also have enabled https support additionally:
Owner: NYCU CSIT
http: http://blackarch.cs.nycu.edu.tw/
https: https://blackarch.cs.nycu.edu.tw/
rsync (blackarch): rsync://blackarch.cs.nycu.edu.tw/blackarch/
Location: Asia Taiwan
Sponsor: Computer Center, Department of Computer Science, National Yang Ming Chiao Tung University
Sponsor URL: https://it.cs.nycu.edu.tw/
Email contact: mirror[at]linux.cs.nycu.edu.tw

Best regards,
Fan Chung,
Computer Center, Department of Computer Science,
National Yang Ming Chiao Tung University, Taiwan.
1001 University Road, Hsinchu, Taiwan 300, ROC.