### PR TITLE
Remove "archlinux" and "blackarch" from pacman-key --populate

### DIFF
--- a/strap.sh
+++ b/strap.sh
@@ -190,7 +190,7 @@ gnupg_trustall_fix() {
     --overwrite --noconfirm
   rm -rf /etc/pacman.d/gnupg
   pacman-key --init
-  pacman-key --populate archlinux blackarch
+  pacman-key --populate
   pacman-key --update --keyserver keyserver.ubuntu.com
 
   msg 'setting IngorePkg gnupg...'


### PR DESCRIPTION
At time of line 193, blackarch.gpg file does not exist (it is still not created), so by running `pacman-key --populate archlinux blackarch` generates the error:
```
==> ERROR: The keyring file /usr/share/pacman/keyrings/blackarch.gpg does not exist.
```
If strap.sh is run in an interactive shell by the user, this error is not blocking. If the script is run by another script inside a process (for example fakechroot during Make), the error will interrupt the process.

The cleanest solution is to replace the line as proposed.