### PR TITLE
strap.sh suggesting installing blackarch-officials instead of forcing

### DIFF
--- a/strap.sh
+++ b/strap.sh
@@ -220,9 +220,10 @@ blackarch_setup()
   msg 'updating package databases'
   pacman_update
   reset_umask
-  msg 'installing blackarch-officials meta-package...'
-  pacman -S --noconfirm --needed blackarch-officials
-  msg 'BlackArch Linux is ready!'
+  #pacman -S --noconfirm --needed blackarch-officials
+  msg 'BlackArch repository is ready!'
+  msg 'You can install blackarch-officials metapackage with the most popular tools using the command below:'
+  msg 'sudo pacman -S --needed blackarch-officials'
 }
 
 blackarch_setup

--- a/strap.sh
+++ b/strap.sh
@@ -220,7 +220,6 @@ blackarch_setup()
   msg 'updating package databases'
   pacman_update
   reset_umask
-  #pacman -S --noconfirm --needed blackarch-officials
   msg 'BlackArch repository is ready!'
   msg 'You can install blackarch-officials metapackage with the most popular tools using the command below:'
   msg 'sudo pacman -S --needed blackarch-officials'


### PR DESCRIPTION
Related to #198 
I opened an issue which says that forcing user to install blackarch-officials is a bad idea.
### Changes I made
- Saying `BlackArch repository ready!` instead of `BlackArch Linux ready!` because this script just sets up the repo
- Removed forced installing of `blackarch-officials` without confirmation
- Added suggestion to install `blackarch-officials`
- Added hint how to  install `blackarch-officials`

### This is how the end of the `strap.sh` execution output looks like after my changes:
```
:: Synchronizing package databases...
 endeavouros                          15,8 KiB  64,3 KiB/s 00:00 [------------------------------------] 100%
 core                                119,5 KiB   660 KiB/s 00:00 [------------------------------------] 100%
 extra                                 7,8 MiB  7,62 MiB/s 00:01 [------------------------------------] 100%
 multilib                            133,3 KiB   629 KiB/s 00:00 [------------------------------------] 100%
 blackarch                             2,3 MiB  1189 KiB/s 00:02 [------------------------------------] 100%
[+] BlackArch repository is ready!
[+] You can install blackarch-officials metapackage with the most popular tools using the command below:
[+] sudo pacman -S --needed blackarch-officials

```