### PR TITLE
Update strap.sh checksum

### DIFF
--- a/checksums/strap
+++ b/checksums/strap
@@ -1,1 +1,1 @@
-bbf0a0b838aed0ec05fff2d375dd17591cbdf8aa  strap.sh
+5c4413d36330018d36f97c517b26d9cd9c1da018  strap.sh


### PR DESCRIPTION
@noraj forgot to change strap.sh sum in 1d48021c9f44968b3182d5f3ab0fe5363734273b and changed only script content.
You can check it by yourself:
```sh
curl https://raw.githubusercontent.com/BlackArch/blackarch-site/master/strap.sh | sha1sum
```