### PR TITLE
Incorrect Address Correction

### DIFF
--- a/blackarch-mirrorlist
+++ b/blackarch-mirrorlist
@@ -80,7 +80,7 @@ Server = https://ftp.halifax.rwth-aachen.de/blackarch/$repo/os/$arch
 #Server = https://ftp.kddilabs.jp/Linux/packages/blackarch/$repo/os/$arch
 
 # Korea
-#Server = https://deny.krfoss.org/blackarch/$repo/os/$arch
+#Server = https://mirror.krfoss.org/blackarch/$repo/os/$arch
 #Server = http://kr.mirrors.cicku.me/blackarch/$repo/os/$arch
 #Server = https://kr.mirrors.cicku.me/blackarch/$repo/os/$arch
 


### PR DESCRIPTION
deny.krfoss.org is not our mirror address.
mirror.krfoss.org is the correct mirror address.