### PR TITLE
New Mirror Submission - mirror.rabisu.com - Germany

### DIFF
--- a/blackarch-mirrorlist
+++ b/blackarch-mirrorlist
@@ -53,6 +53,7 @@ Server = https://ftp.halifax.rwth-aachen.de/blackarch/$repo/os/$arch
 #Server = https://blackarch.unixpeople.org/$repo/os/$arch
 #Server = http://mirror.diyarciftci.xyz/blackarch/$repo/os/$arch
 #Server = https://mirror.diyarciftci.xyz/blackarch/$repo/os/$arch
+#Server = https://mirror.rabisu.com/mirrors/blackarch
 
 # Greece
 #Server = http://ftp.cc.uoc.gr/mirrors/linux/blackarch/$repo/os/$arch


### PR DESCRIPTION
Hello BlackArch Team,

I have added a new mirror located in Germany, hosted by Rabisu.

- **URL:** https://mirror.rabisu.com/mirrors/blackarch/
- **Location:** Germany
- **Bandwidth:** 1Gbps
- **Sync:** Twice a day

The mirror is fully synchronized and ready for use. Thank you!